### PR TITLE
Add Simple Xamarin App

### DIFF
--- a/Source/BlazorState/Pipeline/RenderSubscriptions/RenderSubscriptionsPostProcessor.cs
+++ b/Source/BlazorState/Pipeline/RenderSubscriptions/RenderSubscriptionsPostProcessor.cs
@@ -7,7 +7,7 @@
   using System.Threading;
   using System.Threading.Tasks;
 
-  internal class RenderSubscriptionsPostProcessor<TRequest, TResponse> : IRequestPostProcessor<TRequest, TResponse>
+  public class RenderSubscriptionsPostProcessor<TRequest, TResponse> : IRequestPostProcessor<TRequest, TResponse>
   {
     private readonly ILogger Logger;
 

--- a/Source/BlazorState/Store/Store.ReduxDevTools.cs
+++ b/Source/BlazorState/Store/Store.ReduxDevTools.cs
@@ -11,7 +11,7 @@
   /// The portion of the store that is only needed to support
   /// ReduxDevTools Integration
   /// </summary>
-  internal partial class Store : IReduxDevToolsStore
+  public partial class Store : IReduxDevToolsStore
   {
     /// <summary>
     /// Returns the States in a manner that can be serialized

--- a/Source/BlazorState/Store/Store.cs
+++ b/Source/BlazorState/Store/Store.cs
@@ -7,7 +7,7 @@
 
   /// <summary>
   /// </summary>
-  internal partial class Store : IStore
+  public partial class Store : IStore
   {
     private readonly JsonSerializerOptions JsonSerializerOptions;
     private readonly ILogger Logger;

--- a/Tests/XamarinTestApp/XamarinTestApp.iOS/XamarinTestApp.iOS.csproj
+++ b/Tests/XamarinTestApp/XamarinTestApp.iOS/XamarinTestApp.iOS.csproj
@@ -120,6 +120,9 @@
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="System.Reflection.Emit">
+      <Version>4.6.0</Version>
+    </PackageReference>
     <PackageReference Include="Xamarin.Forms" Version="4.2.0.709249" />
     <PackageReference Include="Xamarin.Essentials" Version="1.2.0" />
   </ItemGroup>

--- a/Tests/XamarinTestApp/XamarinTestApp/App.xaml.cs
+++ b/Tests/XamarinTestApp/XamarinTestApp/App.xaml.cs
@@ -52,9 +52,18 @@ namespace XamarinTestApp
       var builder = new ContainerBuilder();
       builder.AddMediatR(new[] { typeof(IMediator).Assembly, typeof(TestState).Assembly, typeof(ChangeTextCommand).Assembly });
 
+      var blazorStateOptions = new BlazorStateOptions
+      {
+        
+      };
+
+
+      builder.RegisterInstance(blazorStateOptions);
       builder.RegisterGeneric(typeof(NullLogger<>))
       .As(typeof(ILogger<>))
       .SingleInstance();
+
+      builder.RegisterType<TestState>().SingleInstance();
 
       builder.RegisterGeneric(typeof(RenderSubscriptionsPostProcessor<,>))
           .As(typeof(IRequestPostProcessor<,>)).InstancePerLifetimeScope();

--- a/Tests/XamarinTestApp/XamarinTestApp/App.xaml.cs
+++ b/Tests/XamarinTestApp/XamarinTestApp/App.xaml.cs
@@ -1,31 +1,98 @@
-﻿using System;
+﻿
+using Autofac;
+using BlazorState;
+using BlazorState.Features.JavaScriptInterop;
+using BlazorState.Pipeline.State;
+using BlazorState.Services;
+using MediatR;
+using MediatR.Extensions.Autofac.DependencyInjection;
+using MediatR.Pipeline;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using System;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
+using XamarinTestApp;
+using XamarinTestApp.State;
 
 namespace XamarinTestApp
 {
-    public partial class App : Application
+  public partial class App : Application
+  {
+    public static IContainer Container { get; private set; }
+
+    public App()
     {
-        public App()
-        {
-            InitializeComponent();
 
-            MainPage = new MainPage();
-        }
+      Container = CreateContainer();
 
-        protected override void OnStart()
-        {
-            // Handle when your app starts
-        }
+      InitializeComponent();
 
-        protected override void OnSleep()
-        {
-            // Handle when your app sleeps
-        }
-
-        protected override void OnResume()
-        {
-            // Handle when your app resumes
-        }
+      MainPage = new MainPage();
     }
+
+    protected override void OnStart()
+    {
+      // Handle when your app starts
+    }
+
+    protected override void OnSleep()
+    {
+      // Handle when your app sleeps
+    }
+
+    protected override void OnResume()
+    {
+      // Handle when your app resumes
+    }
+
+
+    protected IContainer CreateContainer()
+    {
+      var builder = new ContainerBuilder();
+      builder.AddMediatR(new[] { typeof(IMediator).Assembly, typeof(TestState).Assembly, typeof(ChangeTextCommand).Assembly });
+
+      builder.RegisterGeneric(typeof(NullLogger<>))
+      .As(typeof(ILogger<>))
+      .SingleInstance();
+
+      builder.RegisterGeneric(typeof(RenderSubscriptionsPostProcessor<,>))
+          .As(typeof(IRequestPostProcessor<,>)).InstancePerLifetimeScope();
+      //builder.RegisterGeneric(typeof(RequestValidationBehavior<,>))
+      //    .As(typeof(IPipelineBehavior<,>)).InstancePerLifetimeScope();
+
+      builder.RegisterType<ServiceProvider>().AsImplementedInterfaces();
+      builder.RegisterType(typeof(BlazorHostingLocation)).InstancePerLifetimeScope();
+      builder.RegisterType(typeof(JsonRequestHandler)).InstancePerLifetimeScope();
+      builder.RegisterType(typeof(Subscriptions)).InstancePerLifetimeScope();
+
+      builder.RegisterType<Store>().AsImplementedInterfaces().InstancePerLifetimeScope();
+
+      builder.RegisterType<MainPageViewModel>();
+      //var mediatrOpenTypes = new[]
+      //{
+      //          typeof(IValidator<>),
+      //      };
+
+      //foreach (var mediatrOpenType in mediatrOpenTypes)
+      //{
+      //  builder
+      //      .RegisterAssemblyTypes(typeof(UserState).GetTypeInfo().Assembly, typeof(SyncSitesCommand).Assembly)
+      //      .AsClosedTypesOf(mediatrOpenType)
+      //      .AsImplementedInterfaces();
+      //}
+
+      return builder.Build();
+    }
+  }
 }
+
+public class ServiceProvider : IServiceProvider
+{
+  public object GetService(Type serviceType)
+  {
+    return App.Container.Resolve(serviceType);
+  }
+}
+
+

--- a/Tests/XamarinTestApp/XamarinTestApp/BaseViewModel.cs
+++ b/Tests/XamarinTestApp/XamarinTestApp/BaseViewModel.cs
@@ -1,0 +1,46 @@
+﻿using BlazorState;
+using BlazorState.Components;
+using MediatR;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace XamarinTestApp
+{
+  public abstract class BaseViewModel : BlazorStateViewModel, INotifyPropertyChanged 
+  {
+    public BaseViewModel(IMediator mediator, IStore store, Subscriptions subs) : base(mediator, store, subs)
+    {
+    }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    protected virtual bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string propertyName = null)
+    {
+      if (EqualityComparer<T>.Default.Equals(storage, value)) return false;
+
+      storage = value;
+      RaisePropertyChanged(propertyName);
+
+      return true;
+    }
+
+
+    protected virtual bool SetProperty<T>(ref T storage, T value, Action onChanged, [CallerMemberName] string propertyName = null)
+    {
+      if (EqualityComparer<T>.Default.Equals(storage, value)) return false;
+
+      storage = value;
+      onChanged?.Invoke();
+      RaisePropertyChanged(propertyName);
+
+      return true;
+    }
+
+    protected void RaisePropertyChanged([CallerMemberName]string propertyName = null) => OnPropertyChanged(new PropertyChangedEventArgs(propertyName));
+
+
+    protected virtual void OnPropertyChanged(PropertyChangedEventArgs args) => PropertyChanged?.Invoke(this, args);
+  }
+}

--- a/Tests/XamarinTestApp/XamarinTestApp/Commands/ChangeTextCommand.cs
+++ b/Tests/XamarinTestApp/XamarinTestApp/Commands/ChangeTextCommand.cs
@@ -1,0 +1,14 @@
+﻿using BlazorState;
+
+namespace XamarinTestApp.State
+{
+  public class ChangeTextCommand : IAction
+  {
+
+    public string Text { get; set; }
+    public ChangeTextCommand()
+    {
+      Text = string.Empty;
+    }
+  }
+}

--- a/Tests/XamarinTestApp/XamarinTestApp/Commands/ChangeTextCommandHandler.cs
+++ b/Tests/XamarinTestApp/XamarinTestApp/Commands/ChangeTextCommandHandler.cs
@@ -1,0 +1,25 @@
+﻿using BlazorState;
+using MediatR;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace XamarinTestApp.State
+{
+  public partial class TestState
+  {
+    public class ChangeTextCommandHandler : ActionHandler<ChangeTextCommand>
+    {
+      public ChangeTextCommandHandler(IStore aStore) : base(aStore)
+      {
+      }
+
+      private TestState State => Store.GetState<TestState>();
+      public override Task<Unit> Handle(ChangeTextCommand aAction, CancellationToken aCancellationToken)
+      {
+        State.Text = aAction.Text;
+
+        return Task.FromResult(Unit.Value);
+      }
+    }
+  }
+}

--- a/Tests/XamarinTestApp/XamarinTestApp/MainPage.xaml
+++ b/Tests/XamarinTestApp/XamarinTestApp/MainPage.xaml
@@ -6,10 +6,9 @@
              xmlns:vm="clr-namespace:XamarinTestApp"
              x:DataType="vm:MainPageViewModel"
              mc:Ignorable="d" x:Class="XamarinTestApp.MainPage">
-  <StackLayout>
+  <StackLayout VerticalOptions="Center">
     <Label Text="{Binding TestState.Text}"
-               HorizontalOptions="Center"
-               VerticalOptions="CenterAndExpand"/>
+               HorizontalOptions="Center"/>
     <Button Text="Hey"
             Command="{Binding HeyCommand}"
             BackgroundColor="White"

--- a/Tests/XamarinTestApp/XamarinTestApp/MainPage.xaml
+++ b/Tests/XamarinTestApp/XamarinTestApp/MainPage.xaml
@@ -1,7 +1,26 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" xmlns:d="http://xamarin.com/schemas/2014/forms/design" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d" x:Class="XamarinTestApp.MainPage">
-    <StackLayout>
-        <!-- Place new controls here -->
-        <Label Text="Welcome to Xamarin.Forms!" HorizontalOptions="Center" VerticalOptions="CenterAndExpand" />
-    </StackLayout>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:XamarinTestApp"
+             x:DataType="vm:MainPageViewModel"
+             mc:Ignorable="d" x:Class="XamarinTestApp.MainPage">
+  <StackLayout>
+    <Label Text="{Binding TestState.Text}"
+               HorizontalOptions="Center"
+               VerticalOptions="CenterAndExpand"/>
+    <Button Text="Hey"
+            Command="{Binding HeyCommand}"
+            BackgroundColor="White"
+            BorderColor="Black"
+            TextColor="Black"
+            BorderWidth="3"/>
+    <Button Text="Yo"
+            Command="{Binding YoCommand}"
+            BackgroundColor="White"
+            BorderColor="Black"
+            TextColor="Black"
+            BorderWidth="3"/>
+  </StackLayout>
 </ContentPage>

--- a/Tests/XamarinTestApp/XamarinTestApp/MainPage.xaml.cs
+++ b/Tests/XamarinTestApp/XamarinTestApp/MainPage.xaml.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Xamarin.Forms;
+using Autofac;
 
 namespace XamarinTestApp
 {
@@ -16,6 +17,8 @@ namespace XamarinTestApp
         public MainPage()
         {
             InitializeComponent();
+      var vm = App.Container.BeginLifetimeScope().Resolve<MainPageViewModel>();
+      BindingContext = vm;
         }
     }
 }

--- a/Tests/XamarinTestApp/XamarinTestApp/MainPageViewModel.cs
+++ b/Tests/XamarinTestApp/XamarinTestApp/MainPageViewModel.cs
@@ -1,0 +1,35 @@
+﻿using BlazorState;
+using BlazorState.Components;
+using MediatR;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Xamarin.Forms;
+using XamarinTestApp.State;
+
+namespace XamarinTestApp
+{
+  public class MainPageViewModel : BaseViewModel
+  {
+
+    public TestState TestState { get; }
+
+    public ICommand HeyCommand => new Command(async () => await ChangeText("Hey"));
+
+    public ICommand YoCommand => new Command(async () => await ChangeText("Yo"));
+
+    public MainPageViewModel(IMediator mediator, IStore store, Subscriptions subs) : base(mediator, store, subs)
+    {
+      TestState = GetState<TestState>();
+    }
+
+
+    async Task ChangeText(string text)
+    {
+      await Mediator.Send(new ChangeTextCommand
+      {
+        Text = text
+      });
+    }
+
+  }
+}

--- a/Tests/XamarinTestApp/XamarinTestApp/State/BindableBaseState.cs
+++ b/Tests/XamarinTestApp/XamarinTestApp/State/BindableBaseState.cs
@@ -1,0 +1,40 @@
+﻿using BlazorState;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace XamarinTestApp.State
+{
+  public abstract class BindableBaseState<TState> : State<TState>, INotifyPropertyChanged
+  {
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    protected virtual bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string propertyName = null)
+    {
+      if (EqualityComparer<T>.Default.Equals(storage, value)) return false;
+
+      storage = value;
+      RaisePropertyChanged(propertyName);
+
+      return true;
+    }
+
+    protected virtual bool SetProperty<T>(ref T storage, T value, Action onChanged, [CallerMemberName] string propertyName = null)
+    {
+      if (EqualityComparer<T>.Default.Equals(storage, value)) return false;
+
+      storage = value;
+      onChanged?.Invoke();
+      RaisePropertyChanged(propertyName);
+
+      return true;
+    }
+
+    protected void RaisePropertyChanged([CallerMemberName]string propertyName = null) => OnPropertyChanged(new PropertyChangedEventArgs(propertyName));
+
+
+    protected virtual void OnPropertyChanged(PropertyChangedEventArgs args) => PropertyChanged?.Invoke(this, args);
+  }
+}

--- a/Tests/XamarinTestApp/XamarinTestApp/State/TestState.cs
+++ b/Tests/XamarinTestApp/XamarinTestApp/State/TestState.cs
@@ -1,0 +1,14 @@
+﻿namespace XamarinTestApp.State
+{
+  public partial class TestState : BindableBaseState<TestState>  
+  {
+    string text;
+    public string Text { get => text; private set => SetProperty(ref text, value); }
+
+
+    protected override void Initialize()
+    {
+
+    }
+  }
+}

--- a/Tests/XamarinTestApp/XamarinTestApp/XamarinTestApp.csproj
+++ b/Tests/XamarinTestApp/XamarinTestApp/XamarinTestApp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -6,7 +6,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Autofac" Version="4.9.4" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="MediatR.Extensions.Autofac.DependencyInjection" Version="3.0.1" />
     <PackageReference Include="Xamarin.Forms" Version="4.2.0.709249" />
     <PackageReference Include="Xamarin.Essentials" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\source\BlazorState\BlazorState.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This adds a simple Xamarin app example that uses the State. I think we need to add some code to handle the required registrations into the blazor state project like they do  for web.  Then the classes could stay internal